### PR TITLE
fix: erros de português + palavras não traduzidas

### DIFF
--- a/www/mods/omoriptbr/js/Custom Battle Action Text.js
+++ b/www/mods/omoriptbr/js/Custom Battle Action Text.js
@@ -86,7 +86,7 @@ if (hpDam != 0) {
     hpDamageText = '...Foi um ataque fraco.\r\n' + hpDamageText;
   }
 } else if (result.isHit() === true) {
-  var hpDamageText = "O ataque de " + user.name() + " fez nada.";
+  var hpDamageText = "O ataque de " + user.name() + " não teve efeito.";
 } else {
   var hpDamageText = "O ataque de " + user.name() + " falhou!";
 }

--- a/www/mods/omoriptbr/js/GTP_OmoriFixes.js
+++ b/www/mods/omoriptbr/js/GTP_OmoriFixes.js
@@ -2135,7 +2135,7 @@ Gamefall.OmoriFixes = Gamefall.OmoriFixes || {};
 				// Addon for checking JUICE
 				if(DataManager.isSkill(action.item())) {
 					if(subject.mp < action.item().mpCost) {
-						this._logWindow.push("addText", subject.name().toUpperCase() + " does not have enough JUICE!");
+						this._logWindow.push("addText", subject.name().toUpperCase() + " não tem SUCO o suficiente!");
 						this._logWindow.push("wait");
 					}
 				}		
@@ -2678,7 +2678,7 @@ Gamefall.OmoriFixes = Gamefall.OmoriFixes || {};
 			}
 			if(state.id === target.deathStateId() && target.isActor()) {
 				if([1,8,9,10,11].contains(target.actorId())) {
-					stateMsg = " blacked out!";
+					stateMsg = " desmaiou!";
 				}
 			}
 			if (stateMsg) {

--- a/www/mods/omoriptbr/scripts/02_cutscenes_hideandseek.yml
+++ b/www/mods/omoriptbr/scripts/02_cutscenes_hideandseek.yml
@@ -3,7 +3,7 @@
 # =========================================================================================
 
 message_0:
-      text: Um livro entitulado \c[4]TUDO SOBRE BATALHAS\c[0].\!<br>Você provavelmente deveria ler isso.
+      text: Um livro intitulado \c[4]TUDO SOBRE BATALHAS\c[0].\!<br>Você provavelmente deveria ler isso.
 
 message_1:
       text: Você gostaria de dar uma olhada?

--- a/www/mods/omoriptbr/scripts/dreamworld_npc_dialogue_playground.yml
+++ b/www/mods/omoriptbr/scripts/dreamworld_npc_dialogue_playground.yml
@@ -232,7 +232,7 @@ message_85:
       text: \berE toma esse certificado.\! Mostre pros seus amigos. \!<br>Eles vão ficar orgulhosos!
 
 message_86:
-      text: AUBREY aprendeu a dar \c[1]CABEÇADA\c[0].
+      text: AUBREY aprendeu \c[1]CABEÇADA\c[0].
 
 message_87:
       text: Você ganhou um \c[4]CERTIFICADO DE CABEÇUDA\c[0].

--- a/www/mods/omoriptbr/scripts/new_npcs.yml
+++ b/www/mods/omoriptbr/scripts/new_npcs.yml
@@ -652,11 +652,11 @@ message_140:
 #Brooke
 #Location: Train Station
 message_142:
-      text: \n<BROOKE>Eu sempre me encontro em situações precárias.\!<br>Eu imagino se isso conta...
+      text: \n<BROOKE>Eu sempre me encontro em situações precárias.\!<br>Eu me pergunto se isso conta...
 
 #Location 2: Last Resort Casino
 message_143:
-      text: \n<BROOKE>Eu sempre me encontro em situações precárias.\!<br>Eu imagino se isso conta...
+      text: \n<BROOKE>Eu sempre me encontro em situações precárias.\!<br>Eu me pergunto se isso conta...
 
 message_144:
       text:

--- a/www/mods/omoriptbr/scripts/sidequest_dreamworld_rabbitkiller.yml
+++ b/www/mods/omoriptbr/scripts/sidequest_dreamworld_rabbitkiller.yml
@@ -7,7 +7,7 @@ message_1:
       text: \n<FOLHINHA>Você sabe o que eu odeio mais do que tudo?\!<br>\quake[1]Coelhos.\quake[0]\! Isso mesmo.\! \quake[1]Coelhos.\quake[0]
 
 message_2:
-      text: \n<FOLHINHA>Eu simplesmente odeio eles.\!<br>Se eu pudesse realizar um desejo, <br>eu iria destruir todos os \quake[1]coelhos.\quake[0]
+      text: \n<FOLHINHA>Eu simplesmente odeio eles.\!<br>Se eu pudesse realizar um desejo, <br>eu destruiria todos os \quake[1]coelhos.\quake[0]
 
 #If you killed at least 1 bunny
 


### PR DESCRIPTION
nota adicional:

`AUBREY aprendeu a dar \c[1]CABEÇADA\c[0].` foi mudado para `AUBREY aprendeu \c[1]CABEÇADA\c[0].` para concordar com a forma que está em [dreamworld_npc_dialogue.yml](https://github.com/GabrielZarpellon/omoriptbr/blob/6e5b82ab509e99eec789e1ab5627a3db426acc94/www/mods/omoriptbr/scripts/dreamworld_npc_dialogue.yml#L153)